### PR TITLE
Stop getting stats on pages that are not the home page

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -4,7 +4,6 @@
         <link href="https://fonts.googleapis.com/css2?family=Indie+Flower&family=Kalam&family=Saira+Semi+Condensed&display=swap" rel="stylesheet"> 
         <link href="/css/cssStuff.css" rel="stylesheet" preload="true">
         <link href="/css/eus.css" rel="stylesheet" preload="true">
-        <script src="/js/fetchStats.js"></script>
         <script src="/js/navbarHelper.js"></script>
         <script src="/js/navigationHelper.js"></script>
     </head>
@@ -45,7 +44,6 @@
         <script>
             // Page initialiser
             navbar("Downloads");
-            fetchStatsFromAPI();
         </script>
     </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -4,7 +4,6 @@
         <link href="https://fonts.googleapis.com/css2?family=Indie+Flower&family=Kalam&family=Saira+Semi+Condensed&display=swap" rel="stylesheet"> 
         <link href="/css/cssStuff.css" rel="stylesheet" preload="true">
         <link href="/css/eus.css" rel="stylesheet" preload="true">
-        <script src="/js/fetchStats.js"></script>
         <script src="/js/navbarHelper.js"></script>
         <script src="/js/navigationHelper.js"></script>
     </head>
@@ -42,7 +41,6 @@
         <script>
             // Page initialiser
             navbar("Projects");
-            fetchStatsFromAPI();
         </script>
     </body>
 </html>


### PR DESCRIPTION
While working on #1 I noticed that fetchStatsFromAPI was still being called on pages other than the home which was causing an error + it's also an unnecessary call to the apis