### PR TITLE
Fix server info footer never being updated

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -43,6 +43,7 @@
 
         <script>
             // Page initialiser
+            getServerInfo();
             navbar("Downloads");
         </script>
     </body>

--- a/projects/index.html
+++ b/projects/index.html
@@ -40,6 +40,7 @@
 
         <script>
             // Page initialiser
+            getServerInfo();
             navbar("Projects");
         </script>
     </body>


### PR DESCRIPTION
I didn't notice this while working on #2 but after those changes the server info footers on the downloads page and projects page would never change.

This is because the API calls were removed on those pages and I didn't foresee that the removal of both APIs would break that.

This issue can currently be seen at these links: [EUS Downloads](https://ethanus.ml/downloads/), [EUS Projects](https://ethanus.ml/projects/)